### PR TITLE
Add quick_replies structure and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ client = MessengerClient(os.environ.get('FACEBOOK_PAGE_TOKEN'))
 client.send('recipient_id', TextMessage('message'))
 ```
 
+To send a quick reply:
+
+```python
+import os
+
+from messenger import MessengerClient
+from messenger.content_types import QuickReply
+
+text = 'message'
+quick_reply_one = {
+    'content_type': 'text',
+    'payload': '<PAYLOAD>',
+    'title': '<TITLE>',
+    'image_url': '<IMAGE_URL>' or None
+}
+quick_reply_two = {
+    'content_type': 'location'
+}
+
+client = MessengerClient(os.environ.get('FACEBOOK_PAGE_TOKEN'))
+client.send('recipient_id', QuickReply(text, quick_reply_one, quick_reply_two))
+```
+
+
 ## Development
 
 Run tests:

--- a/messenger/content_types.py
+++ b/messenger/content_types.py
@@ -20,6 +20,47 @@ class TextMessage(object):
         return {'text': self.text}
 
 
+class QuickReply(object):
+    """Send plain quick replies using the
+    [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
+    """
+
+    def __init__(self, text, *hash_list):
+        self.text = text
+        for dictionary in hash_list:
+            self.dictionary = dictionary
+        """
+        Key parameters
+        ----------
+        content_type : str
+            required
+            supported formats are "location" and "text"
+        title : str
+            required if content_type is text
+            must be UTF-8 and has a 20 character limit.
+        payload : str or int
+            required if content_type is text
+            must be UTF-8 and has a 1000 character limit.
+        image_url : str
+            not required, however, should be set to None in the dictionary
+            image should be at least 24x24
+        """
+    def message(self):
+        quick_replies = []
+        for key in self.dictionary:
+            print(key['content_type'])
+            if key['content_type'] == 'location':
+                quick_replies.append({'content_type': 'location'})
+            elif key['content_type'] == 'text':
+                quick_replies.append({
+                    'content_type': 'text',
+                    'title': key['title'],
+                    'payload': key['payload'],
+                    'image_url': key['image_url']
+            })
+        return {'text': self.text, 'quick_replies': quick_replies}
+
+
 class AudioAttachment(object):
     """Send sounds by uploading them or sharing a URL using the
     [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).

--- a/requirements/package.txt
+++ b/requirements/package.txt
@@ -1,1 +1,2 @@
 setuptools
+requests

--- a/tests/messenger/content_types/test_quick_reply.py
+++ b/tests/messenger/content_types/test_quick_reply.py
@@ -1,0 +1,30 @@
+from messenger.content_types import QuickReply
+
+
+class TestQuickReply(object):
+    def test_quick_reply(self):
+        text = 'Message'
+        quick_reply_one = {
+            'content_type': 'text',
+            'payload': 'random_payload1',
+            'title': 'title1',
+            'image_url': None
+        }
+        quick_reply_two = {
+            'content_type': 'location'
+        }
+
+        assert QuickReply(text, [quick_reply_one, quick_reply_two]).message() == {
+            'text': 'Message',
+            'quick_replies': [
+                {
+                    'content_type': 'text',
+                    'payload': 'random_payload1',
+                    'title': 'title1',
+                    'image_url': None
+
+                },
+                {
+                    'content_type': 'location'
+                }
+            ]}


### PR DESCRIPTION
- Implement `quick_replies` structure. 
     - I don't think this is the best option to send quick replies, (it looks weird having to specify the `title`, `content_type`, the user shouldn't have to do this explicitly, but rather we should figure out how to handle this) however, I couldn't think of another manner to be able to manage more than one quick reply button being sent.
- Update README.md to include how to send a quick reply